### PR TITLE
chore: Remove unneeded remappings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,4 @@ test = "test"
 out = "artifacts"
 lib = ["node_modules", "lib"]
 
-# allow_paths = ["../../node_modules"]
-
-remappings = ["forge-std/=/lib/forge-std/", "@eth-optimism/=node_modules/@eth-optimism/", "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/", "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/"]
+remappings = []


### PR DESCRIPTION
- Remove remappings that are unneeded
- because node_modules is added to lib they are already remapped

Test
- Ran build and checked typechecker still worked